### PR TITLE
fix:  bug fixes with docker run and tensorrt inference sample.

### DIFF
--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,3 +1,4 @@
-docker rm -f ffs
+docker rm -f ffs || true
+xhost +local:root || true
 DIR=$(pwd)/../
-docker run --gpus all --env NVIDIA_DISABLE_REQUIRE=1 -it --network=host --name ffs --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $DIR:/workspace --ipc=host -e DISPLAY=${DISPLAY} -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp:/tmp -v /home:/home -v /mnt:/mnt ffs bash
+docker run --gpus all --env NVIDIA_DISABLE_REQUIRE=1 -it --network=host --name ffs --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $DIR:/workspace --ipc=host -e DISPLAY=${DISPLAY} -e LIBGL_ALWAYS_SOFTWARE=1 -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp:/tmp -v /home:/home -v /mnt:/mnt ffs bash

--- a/scripts/run_demo_tensorrt.py
+++ b/scripts/run_demo_tensorrt.py
@@ -27,6 +27,7 @@ if __name__=="__main__":
   parser.add_argument('--denoise_radius', type=float, default=0.03, help='radius to use for outlier removal')
   parser.add_argument('--get_pc', type=int, default=1, help='save point cloud output')
   parser.add_argument('--zfar', type=float, default=100, help="max depth to include in point cloud")
+  parser.add_argument('--image_size', type=int, nargs='+', default=[448, 640], help="image size, should match the image size used to generate the tensorrt engine")
   args = parser.parse_args()
 
   set_logging_format()
@@ -96,7 +97,7 @@ if __name__=="__main__":
       lines = f.readlines()
       K = np.array(list(map(float, lines[0].rstrip().split()))).astype(np.float32).reshape(3,3)
       baseline = float(lines[1])
-    K[:2] *= np.array([fx, fy])
+      K[:2] *= np.array([[fx], [fy]])
     depth = K[0,0]*baseline/disp
     np.save(f'{args.out_dir}/depth_meter.npy', depth)
     xyz_map = depth2xyzmap(depth, K)


### PR DESCRIPTION
Hi, NVLabs team, thanks for the amazing work! Just wanted to contribute this minor fix that I have come across when testing the repo with TensorRT; details bellow:

Fixes runtime bugs with the Docker container setup and the TensorRT sample. 

- `docker/run_container.sh`: added `xhost` permission fix, `LIBGL_ALWAYS_SOFTWARE=1` env var, and graceful `docker rm` failure.
- `scripts/run_demo_tensorrt.py`: added an `--image_size` argument to match the generated `tensorrt` engine, and fixed a NumPy broadcasting shape mismatch error when scaling the intrinsic matrix `K`.