### PR TITLE
Fix formatting of ENV PATH in Dockerfile

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -19,7 +19,7 @@ RUN cd / && wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-L
     /opt/conda/bin/conda update -n base -c defaults conda -y &&\
     /opt/conda/bin/conda create -n my python=3.12
 
-ENV PATH $PATH:/opt/conda/envs/my/bin
+ENV PATH=$PATH:/opt/conda/envs/my/bin
 ENV OPENCV_IO_ENABLE_OPENEXR=1
 
 RUN conda init bash &&\


### PR DESCRIPTION
[Low Priority] Fix formatting of ENV PATH in Dockerfile to avoid Docker building warning `LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 22)`