### PR TITLE
Docker: enable GUI forwarding from container (Qt/xcb + Open3D)

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -4,7 +4,7 @@ ENV TZ=US/Pacific
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y apt-utils build-essential ca-certificates cmake curl ffmpeg git libturbojpeg-dev pkg-config wget libnvinfer10 libnvinfer-plugin10 libnvonnxparsers10 libnvinfer-dispatch10 libnvinfer-bin zstd && \
+    apt-get install -y apt-utils build-essential ca-certificates cmake curl ffmpeg git libturbojpeg-dev pkg-config wget libnvinfer10 libnvinfer-plugin10 libnvonnxparsers10 libnvinfer-dispatch10 libnvinfer-bin zstd libx11-xcb1 libxcb-xinerama0 libxcb-icccm4 libxcb-render-util0 libxcb-shape0 libxcb-keysyms1 libxcb-image0 libxkbcommon-x11-0 libxcb-cursor0 libxcb-xkb1 libxcb-render0 libxcb-shm0 libxcb-sync1 libxcb-xfixes0 libxcb-randr0 libxcb-xtest0 libsm6 libxext6 libxkbcommon0 && \
     rm -rf /var/lib/apt/lists/*
 
 SHELL ["/bin/bash", "--login", "-c"]
@@ -19,7 +19,7 @@ RUN cd / && wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-L
     /opt/conda/bin/conda update -n base -c defaults conda -y &&\
     /opt/conda/bin/conda create -n my python=3.12
 
-ENV PATH $PATH:/opt/conda/envs/my/bin
+ENV PATH=$PATH:/opt/conda/envs/my/bin
 ENV OPENCV_IO_ENABLE_OPENEXR=1
 
 RUN conda init bash &&\

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,3 +1,4 @@
 docker rm -f ffs
 DIR=$(pwd)/../
-docker run --gpus all --env NVIDIA_DISABLE_REQUIRE=1 -it --network=host --name ffs --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $DIR:/workspace --ipc=host -e DISPLAY=${DISPLAY} -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp:/tmp -v /home:/home -v /mnt:/mnt ffs bash
+mkdir -p /tmp/runtime
+docker run --gpus all --env NVIDIA_DISABLE_REQUIRE=1 -it --network=host --name ffs --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $DIR:/workspace --ipc=host -e DISPLAY=${DISPLAY} -e QT_X11_NO_MITSHM=1 -e QT_DEBUG_PLUGINS=0 -e XDG_RUNTIME_DIR=/tmp/runtime -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp:/tmp -v /home:/home -v /mnt:/mnt ffs bash


### PR DESCRIPTION
## What
- Dockerfile: Install X11/xcb and related libs so OpenCV’s Qt backend can show windows when using host X11 forwarding (`cv2.imshow`). Adds **`libsm6`** (fixes missing `libSM.so.6`), plus `libx11-xcb1`, `libxcb-*`, `libxext6`, etc. Uses **`libxcb-sync1`** for Ubuntu 22.04 (not `libxcb-sync0`).
- **Dockerfile:** `ENV PATH=$PATH:/opt/conda/envs/my/bin`, modern `ENV` form (silences Docker `LegacyKeyValueFormat` warning). 
- `run_container.sh`: set `XDG_RUNTIME_DIR` + create `/tmp/runtime` for Open3D; `QT_X11_NO_MITSHM=1`; optional `QT_DEBUG_PLUGINS=0`.

## Why
Without these system libraries, Qt fails to load the `xcb` platform plugin inside the container even with `DISPLAY` and `/tmp/.X11-unix` mounted. Open3D may error if `XDG_RUNTIME_DIR` is unset.

## How to verify
1. On host: `xhost +local:root`
2. Build image, run `bash docker/run_container.sh`
3. Run a script that uses `cv2.imshow` and/or Open3D visualization -> windows should appear on the host.